### PR TITLE
Add Offer entity and related database schema changes

### DIFF
--- a/src/MeetApp.Database/AppDbContext.cs
+++ b/src/MeetApp.Database/AppDbContext.cs
@@ -9,6 +9,8 @@ namespace MeetApp.Database
     public class AppDbContext : IdentityDbContext<User, Role, Guid>
     {
 
+        public virtual DbSet<Offer> Offers { get; set; }
+
         public AppDbContext(DbContextOptions<AppDbContext> dbContextOptions) : base(dbContextOptions) { }
 
     }

--- a/src/MeetApp.Database/Migrations/20241016172043_Offers_CREATE.Designer.cs
+++ b/src/MeetApp.Database/Migrations/20241016172043_Offers_CREATE.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MeetApp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MeetApp.Database.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241016172043_Offers_CREATE")]
+    partial class Offers_CREATE
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MeetApp.Database/Migrations/20241016172043_Offers_CREATE.cs
+++ b/src/MeetApp.Database/Migrations/20241016172043_Offers_CREATE.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MeetApp.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class Offers_CREATE : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Offers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    BusinessId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    ExpirationDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    Tag = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Offers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Offers_AspNetUsers_BusinessId",
+                        column: x => x.BusinessId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Offers_BusinessId",
+                table: "Offers",
+                column: "BusinessId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Offers");
+        }
+    }
+}

--- a/src/MeetApp.Database/Models/Offer.cs
+++ b/src/MeetApp.Database/Models/Offer.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Identity;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MeetApp.Database.Models
+{
+
+    public class Offer
+    {
+        [Key]
+        public Guid Id { get; set; }
+
+        public Guid BusinessId { get; set; }
+
+        [Required]
+        [StringLength(128)]
+        public string Title { get; set; }
+
+        [Required]
+        [StringLength(1024)]
+        public string Description { get; set; }
+
+        [Required]
+        public DateOnly ExpirationDate { get; set; }
+
+        [StringLength(16)]
+        public string Tag { get; set; }
+
+        [ForeignKey(nameof(BusinessId))]
+        [InverseProperty(nameof(User.Offers))]
+        public virtual User Bussines { get; set; }
+    }
+
+
+}

--- a/src/MeetApp.Database/Models/User.cs
+++ b/src/MeetApp.Database/Models/User.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace MeetApp.Database.Models
 {
@@ -32,6 +34,9 @@ namespace MeetApp.Database.Models
             Cinema = 2,
         }
         /* BUSSINES FIELDS */
+
+        [InverseProperty(nameof(Offer.Bussines))]
+        public virtual ICollection<Offer> Offers { get; set; } = [];
 
     }
 


### PR DESCRIPTION
Ref: #22

- Added DbSet<Offer> to AppDbContext for managing Offer entities.
- Created migration 20241016172043_Offers_CREATE for Offers table.
- Defined Offer entity with properties: Id, BusinessId, Title, Description, ExpirationDate, and Tag.
- Established foreign key relationship between Offer and User entities.
- Updated User entity to include a collection of Offers.
- Updated AppDbContextModelSnapshot to reflect new Offers table and relationships.