### PR TITLE
Add DeleteAsync method to OffersController

### DIFF
--- a/src/MeetApp.Backend/Controllers/Api/V1/OffersController.cs
+++ b/src/MeetApp.Backend/Controllers/Api/V1/OffersController.cs
@@ -1,0 +1,86 @@
+﻿using MeetApp.Database;
+using MeetApp.Database.Models;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Net.Mime;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MeetApp.Backend.Controllers.Api.V1
+{
+
+    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+    [ApiController]
+    [ApiExplorerSettings(GroupName = "v1")]
+    [Route("/api/v1/offers")]
+    public class OffersController : ControllerBase
+    {
+
+        private readonly AppDbContext appDbContext;
+
+        public OffersController(
+            AppDbContext appDbContext
+        )
+        {
+            this.appDbContext = appDbContext;
+        }
+
+        [AllowAnonymous]
+        [Consumes(MediaTypeNames.Application.Json)]
+        [HttpPost]
+        [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType<OfferCreateResponse>(StatusCodes.Status200OK)]
+        [ProducesResponseType<OfferCreateResponse>(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> CreateAsync([FromBody][Required] OfferCreateRequest offerCreateRequest, CancellationToken cancellationToken = default)
+        {
+            var offer = new Offer
+            {
+                Bussines = await this.appDbContext.Users
+                    .Where(x => x.Id == offerCreateRequest.BussinesId)
+                    .SingleAsync(cancellationToken),
+                Description = offerCreateRequest.Description,
+                ExpirationDate = offerCreateRequest.ExpirationDate,
+                Tag = offerCreateRequest.Tag,
+                Title = offerCreateRequest.Title,
+            };
+            this.appDbContext.Offers.Add(offer);
+            _ = await this.appDbContext.SaveChangesAsync(cancellationToken);
+            return this.Ok(new OfferCreateResponse
+            {
+                BussinesId = offer.Bussines.Id,
+                Description = offer.Description,
+                ExpirationDate = offer.ExpirationDate,
+                Id = offer.Id,
+                Tag = offer.Tag,
+                Title = offer.Title,
+            });
+        }
+
+        public record OfferCreateRequest
+        {
+            public required Guid BussinesId { get; init; }
+            public required string Description { get; init; }
+            public required DateOnly ExpirationDate { get; init; }
+            public string? Tag { get; init; }
+            public required string Title { get; init; }
+        }
+
+        public record OfferCreateResponse
+        {
+            public required Guid BussinesId { get; init; }
+            public required string Description { get; init; }
+            public required DateOnly ExpirationDate { get; init; }
+            public required Guid Id { get; init; }
+            public string? Tag { get; init; }
+            public required string Title { get; init; }
+        }
+
+    }
+
+}

--- a/src/MeetApp.Backend/Controllers/Api/V1/OffersController.cs
+++ b/src/MeetApp.Backend/Controllers/Api/V1/OffersController.cs
@@ -81,6 +81,24 @@ namespace MeetApp.Backend.Controllers.Api.V1
             public required string Title { get; init; }
         }
 
+
+        [AllowAnonymous]
+        [HttpDelete("{id}")]
+        [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeleteAsync([FromRoute] Guid id, CancellationToken cancellationToken = default)
+        {
+            var offer = await appDbContext.Offers.Where(x => x.Id == id).FirstOrDefaultAsync(cancellationToken);
+            if (offer == null)
+            {
+                return NotFound();
+            }
+            appDbContext.Offers.Remove(offer);
+            _ = appDbContext.SaveChangesAsync(cancellationToken);
+            return Ok();
+        }
+  
     }
 
 }

--- a/src/MeetApp.Backend/Controllers/Api/V1/OffersController.cs
+++ b/src/MeetApp.Backend/Controllers/Api/V1/OffersController.cs
@@ -98,7 +98,7 @@ namespace MeetApp.Backend.Controllers.Api.V1
             _ = appDbContext.SaveChangesAsync(cancellationToken);
             return Ok();
         }
-  
+
     }
 
 }

--- a/src/MeetApp.Database/Migrations/20241016172043_Offers_CREATE.cs
+++ b/src/MeetApp.Database/Migrations/20241016172043_Offers_CREATE.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
 
 #nullable disable
 

--- a/src/MeetApp.Database/Models/Offer.cs
+++ b/src/MeetApp.Database/Models/Offer.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Identity;
-using System;
+﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 


### PR DESCRIPTION
Closes: #46 


A new DeleteAsync method has been added to the OffersController class in the MeetApp.Backend.Controllers.Api.V1 namespace. This method is an HTTP DELETE endpoint that allows anonymous users to delete an offer by its id.

The method is decorated with several attributes:
- [AllowAnonymous] allows the endpoint to be accessed without authentication.
- [HttpDelete("{id}")] specifies that this is an HTTP DELETE request and the id parameter is taken from the route.
- [Produces(MediaTypeNames.Application.Json)] indicates that the response will be in JSON format.
- [ProducesResponseType(StatusCodes.Status200OK)] indicates that a 200 OK status will be returned if the deletion is successful.
- [ProducesResponseType(StatusCodes.Status404NotFound)] indicates that a 404 Not Found status will be returned if the offer with the specified id does not exist.

The method retrieves the offer from the database using the provided id. If the offer is found, it is removed from the database and a 200 OK response is returned. If the offer is not found, a 404 Not Found response is returned.