### PR TITLE
new endpoints to OfferController and UserController

### DIFF
--- a/src/MeetApp.Backend/Controllers/Api/V1/OfferController.cs
+++ b/src/MeetApp.Backend/Controllers/Api/V1/OfferController.cs
@@ -70,6 +70,42 @@ namespace MeetApp.Backend.Controllers.Api.V1
                 .ToListAsync(cancellationToken);
             return this.Ok(result);
         }
+        [AllowAnonymous]
+        [HttpGet("getoffers")]
+        [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType<ICollection<OfferPaidResponse>>(StatusCodes.Status200OK)]
+        [ProducesResponseType<ICollection<OfferPaidResponse>>(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetByPaid(CancellationToken cancellationToken = default)
+        {
+            var result = await appDbContext.Offers
+                .Where(offer => offer.Paid)
+                .Include(offer => offer.Bussines)
+                .OrderBy(offer => offer.Bussines.BussinesName)
+                .Select(offer => new OfferPaidResponse
+                {
+                    BussinesId = offer.Bussines.Id,
+                    BusinessName = offer.Bussines.BussinesName,
+                    Description = offer.Description,
+                    ExpirationDate = offer.ExpirationDate,
+                    Id = offer.Id,
+                    Paid = offer.Paid,
+                    Tag = offer.Tag,
+                    Title = offer.Title,
+                })
+                .ToListAsync(cancellationToken);
+            return this.Ok(result);
+        }
+        public record OfferPaidResponse
+        {
+            public required Guid BussinesId { get; init; }
+            public required string BusinessName { get; init; }
+            public required string Description { get; init; }
+            public required DateOnly ExpirationDate { get; init; }
+            public required Guid Id { get; init; }
+            public required bool Paid { get; init; }
+            public string? Tag { get; init; }
+            public required string Title { get; init; }
+        }
 
         [AllowAnonymous]
         [HttpGet("{id}")]
@@ -111,7 +147,6 @@ namespace MeetApp.Backend.Controllers.Api.V1
                     Title = x.Title,
                 });
         }
-
         public record OfferCreateRequest
         {
             public required Guid BussinesId { get; init; }

--- a/src/MeetApp.Backend/Controllers/Api/V1/OfferController.cs
+++ b/src/MeetApp.Backend/Controllers/Api/V1/OfferController.cs
@@ -84,6 +84,19 @@ namespace MeetApp.Backend.Controllers.Api.V1
             return this.Ok(result);
         }
 
+        [AllowAnonymous]
+        [HttpGet("business/{businessId}")]
+        [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType<ICollection<OfferReadResponse>>(StatusCodes.Status200OK)]
+        [ProducesResponseType<ICollection<OfferReadResponse>>(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetByBusinessId ([FromRoute] Guid businessId, CancellationToken cancellationToken = default)
+        {
+            var result = await this.Read()
+                .Where(offer=>offer.BussinesId == businessId)
+                .ToListAsync(cancellationToken);
+            return this.Ok(result);
+        }
+
         private IQueryable<OfferReadResponse> Read()
         {
             return this.appDbContext.Offers

--- a/src/MeetApp.Backend/Controllers/Api/V1/UserController.cs
+++ b/src/MeetApp.Backend/Controllers/Api/V1/UserController.cs
@@ -1,4 +1,5 @@
-﻿using MeetApp.Database.Models;
+﻿using MeetApp.Database;
+using MeetApp.Database.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -32,7 +33,6 @@ namespace MeetApp.Backend.Controllers.Api.V1
         UserManager<User> userManager
     ) : ControllerBase
     {
-
         private readonly IConfiguration configuration = configuration;
         private readonly UserManager<User> userManager = userManager;
 
@@ -96,6 +96,71 @@ namespace MeetApp.Backend.Controllers.Api.V1
             var identityResult = await this.userManager.CreateAsync(user, registrationRequest.Password);
             if (identityResult.Succeeded) { return this.Ok(); }
             return this.BadRequest();
+        }
+        [AllowAnonymous]
+        [HttpPut("businessUpdate/{id}")]
+        [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> UpdateBusinessUser([FromForm][Required] BusinessUserUpdateRequest userUpdateRequest, [FromRoute] Guid id, CancellationToken cancellationToken=default)
+        {
+            var user = await userManager.FindByIdAsync(id.ToString());
+            if (user is null)
+            {
+                return NotFound();
+            }
+            user.BussinesName = userUpdateRequest.BusinessName;
+            user.Email = userUpdateRequest.Email;
+            user.City = userUpdateRequest.City;
+            user.ProfilePicture = userUpdateRequest.ProfilePictureUrl;
+            user.CIF = userUpdateRequest.CIF;
+            user.BussinesAddress = userUpdateRequest.BusinessAdress;
+            user.GoogleMapsUrl = userUpdateRequest.GoogleMapsUrl;
+            user.Longitude = userUpdateRequest.Longitude;
+            user.Latitude = userUpdateRequest.Latitude;
+            _ =await userManager.UpdateAsync(user);
+            return Ok(user);
+        }
+        public record BusinessUserUpdateRequest
+        {
+            public required string BusinessName { get; set; }
+            public required string Email { get; set; }
+            public required string City { get; set; }
+            public required string ProfilePictureUrl { get; set; }
+            public required string CIF { get; set; }
+            public required string BusinessAdress { get; set; }
+            public required string GoogleMapsUrl{ get; set; }
+            public required decimal Longitude { get; set; }
+            public required decimal Latitude { get; set; }
+        }
+
+        [AllowAnonymous]
+        [HttpPut("userUpdate/{id}")]
+        [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> UpdateUser([FromForm][Required] UserUpdateRequest userUpdateRequest, [FromRoute] Guid id, CancellationToken cancellationToken = default)
+        {
+            var user = await userManager.FindByIdAsync(id.ToString());
+            if (user is null)
+            {
+                return NotFound();
+            }
+            user.Name = userUpdateRequest.Name;
+            user.Email = userUpdateRequest.Email;
+            user.City = userUpdateRequest.City;
+            user.ProfilePicture = userUpdateRequest.ProfilePictureUrl;
+            _ = await userManager.UpdateAsync(user);
+            return Ok(user);
+        }
+        public record UserUpdateRequest
+        {
+            public required string Email { get; set; }
+            public required string City { get; set; }
+            public required string ProfilePictureUrl { get; set; }
+            public required string Name { get; set; }
         }
 
         [AllowAnonymous]

--- a/src/MeetApp.Backend/Controllers/Api/V1/UserController.cs
+++ b/src/MeetApp.Backend/Controllers/Api/V1/UserController.cs
@@ -134,7 +134,31 @@ namespace MeetApp.Backend.Controllers.Api.V1
             public required decimal Longitude { get; set; }
             public required decimal Latitude { get; set; }
         }
+        [AllowAnonymous]
+        [HttpGet("businesses")]
+        [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType<ICollection<BusinessInfoResponse>>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetAllBusinesses(CancellationToken cancellationToken = default)
+        {
+            var result = await userManager.Users
+                .Select(user => new BusinessInfoResponse
+                {
+                    BusinessId = user.Id,
+                    BusinessName = user.BussinesName,
+                    ProfilePicture = user.ProfilePicture
+                })
+                .ToListAsync(cancellationToken);
 
+            return Ok(result);
+        }
+
+        public record BusinessInfoResponse
+        {
+            public required Guid BusinessId { get; init; }
+            public required string? BusinessName { get; init; }
+            public required string? ProfilePicture { get; init; }
+        }
         [AllowAnonymous]
         [HttpPut("userUpdate/{id}")]
         [Consumes(MediaTypeNames.Application.Json)]


### PR DESCRIPTION
Add new endpoints to OfferController and UserController

- Added `GetByPaid` endpoint to `OfferController` to return a list of paid offers, ordered by business name. This endpoint is accessible without authentication and returns a JSON response with status codes 200 or 400. Introduced `OfferPaidResponse` record for response data.

- Added `GetAllBusinesses` endpoint to `UserController` to return a list of businesses. This endpoint is accessible without authentication and returns a JSON response with status codes 200 or 400. Introduced `BusinessInfoResponse` record for response data.